### PR TITLE
Improve readme and some bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,130 @@ Supported formats:
 - IMOD
 - AreTomo3
 - cryoet-data-portal
+
+# Installation
+
+`cryoet-alignment` can be installed using pip:
+
+```bash
+pip install cryoet-alignment
+```
+
+# Usage
+
+## Reading and writing alignment files
+
+`cryoet-alignment` provides a simple API to read and write alignment files from different software packages.
+
+### IMOD
+When processing tomography data using IMOD/etomo, files containing relevant alignment information are usually stored
+following the naming convention `basename.xf` (in-plane parameters), `basename.tlt` (tilt angles),
+`basename.xtilt` (x-rotation), `basename.mrc` (unaligned tilt series) and `basename_full_rec.mrc` (tomogram).
+
+This layout is assumed when reading and writing IMOD alignment files as shown below. Any present `tilt.com` and
+`newst.com` file in the same directory may also be read.
+
+```python
+from cryoet_alignment import read
+from cryoet_alignment import write
+
+# Read IMOD alignment files using etomo basename
+imod_alignment = read("/path/to/imod_dir/basename")
+
+# Write IMOD file
+write(imod_alignment, "/path/to/imod_dir/basename")
+```
+
+### AreTomo3
+When processing tomography data using AreTomo3, alignment information is stored in a single `.aln` file. This file can be
+read and written as shown below.
+
+```python
+from cryoet_alignment import read
+from cryoet_alignment import write
+
+# Read AreTomo3 alignment files
+aretomo3_alignment = read("/path/to/alignment_file.aln")
+
+# Write AreTomo3 file
+write(aretomo3_alignment, "/path/to/alignment_file.aln")
+```
+
+### cryoet-data-portal
+Alignment information from the cryoet-data-portal is stored in a JSON file with a schema described here. This file can
+be read and written as shown below.
+
+```python
+from cryoet_alignment import read
+from cryoet_alignment import write
+
+# Read cryoet-data-portal alignment files
+cryoet_data_portal_alignment = read("/path/to/alignment_file.json")
+
+# Write cryoet-data-portal file
+write(cryoet_data_portal_alignment, "/path/to/alignment_file.json")
+```
+
+## Convert between different alignment formats
+
+`cryoet-alignment` provides the ability to convert between different alignment formats. For any conversion, the
+alignment object must be read first using the appropriate `read` function, and then converted to the cryoet-data-portal
+format before converting and writing to the desired format.
+
+### IMOD to AreTomo3
+```python
+from cryoet_alignment import read, write
+from cryoet_alignment.io.cryoet_data_portal import Alignment
+
+# Read IMOD alignment files using etomo basename
+imod_alignment = read("/path/to/imod_dir/basename")
+
+# Convert IMOD to AreTomo3
+cdp_alignment = Alignment.from_imod(imod_alignment)
+
+# Write AreTomo3 file
+tilt_series_dim = (4096, 4096, 41)
+write(cdp_alignment.to_aretomo(ts_size=tilt_series_dim), "/path/to/alignment_file.aln")
+```
+
+### cryoet-data-portal to IMOD
+
+It is also possible to convert directly from the cryoet-data-portal client to IMOD/AreTomo format. This is demonstrated
+below. This requires additional dependencies to be installed using the following command:
+
+```bash
+pip install cryoet-alignment[cdp]
+```
+
+To convert from the cryoet-data-portal to IMOD, the below code can be used. Briefly, given a tomogram ID, the snippet
+fetches the alignment information from the cryoet-data-portal, reads the tilt series metadata, and converts the alignment
+to IMOD format. The resulting alignment files are written to the specified directory with the portal's run name as
+the base name.
+
+```python
+import cryoet_data_portal as cdp
+import zarr
+from cryoet_alignment.io.cryoet_data_portal import Alignment
+from cryoet_alignment import write
+
+# Target tomogram ID
+# This is an example from dataset 10004 (https://cryoetdataportal.czscience.com/runs/333)
+TOMO_ID = 771
+
+# Get the tomogram from the cryoet-data-portal
+client = cdp.Client()
+tomogram = cdp.Tomogram.get_by_id(client, TOMO_ID)
+
+# Read cryoet-data-portal alignment from S3
+cdp_ali = Alignment.from_s3(tomogram.alignment.s3_alignment_metadata)
+
+# Get the tilt series metadata
+#tilt_series = tomogram.alignment.tiltseries < currently unavailable due to a bug in the data portal client
+tilt_series = tomogram.run.tiltseries[0]
+pixel_size = tilt_series.pixel_spacing
+dim_z, dim_y, dim_x = zarr.open(tilt_series.s3_omezarr_dir)['0'].shape
+
+# Convert to IMOD format
+imod_ali = cdp_ali.to_imod(ts_size=(dim_x, dim_y, dim_z), ts_spacing=pixel_size)
+write(imod_ali, f"/tmp/test/{tomogram.run.name}")
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
 ]
-#dynamic = ["version"]
-version = "0.0.7"
+dynamic = ["version"]
 dependencies = [
     "click",
     "fsspec>=2024.6.0",
@@ -19,6 +18,7 @@ dependencies = [
     "pydantic>=2",
     "s3fs",
     "pandas",
+    "cryoet-data-portal>=4.0.0",
 ]
 authors = [
   {name = "Utz H. Ermel", email = "utz.ermel@czii.org"},
@@ -33,6 +33,10 @@ Repository = "https://github.com/uermel/cryoet-alignment.git"
 Issues = "https://github.com/uermel/cryoet-alignment/issues"
 
 [project.optional-dependencies]
+cdp = [
+    "cryoet-data-portal>=4.0.0",
+    "zarr",
+]
 test = [
     "pytest",
     "pytest-cov",
@@ -51,8 +55,8 @@ docs = [
     "mkdocs-material",
 ]
 
-[project.scripts]
-make_templates = "copick.cli.make_templates:create [docs]"
+[tool.hatch.version]
+path = "src/copick/__init__.py"
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ docs = [
 ]
 
 [tool.hatch.version]
-path = "src/copick/__init__.py"
+path = "src/cryoet_alignment/__init__.py"
 
 [tool.black]
 line-length = 120

--- a/src/cryoet_alignment/__init__.py
+++ b/src/cryoet_alignment/__init__.py
@@ -1,0 +1,9 @@
+__version__ = "0.0.8"
+
+from cryoet_alignment.api.read import read
+from cryoet_alignment.api.write import write
+
+__all__ = [
+    "read",
+    "write",
+]

--- a/src/cryoet_alignment/api/read.py
+++ b/src/cryoet_alignment/api/read.py
@@ -15,6 +15,18 @@ def read_imod(
     tiltcom_path: PATH_TYPE = None,
     newstcom_path: PATH_TYPE = None,
 ) -> ImodAlignment:
+    """Read an IMOD alignment from the specified files.
+
+    Args:
+        xf_path: The path to the .xf file.
+        tlt_path: The path to the .tlt file.
+        xtilt_path: The path to the .xtilt file.
+        tiltcom_path: The path to the .tiltcom file.
+        newstcom_path: The path to the .newstcom file.
+
+    Returns:
+        ImodAlignment: The alignment object.
+    """
     return ImodAlignment.read(
         xf_path=xf_path,
         tlt_path=tlt_path,
@@ -27,14 +39,39 @@ def read_imod(
 def read_imod_basename(
     base_name: str,
 ) -> ImodAlignment:
+    """Read an IMOD alignment from the specified basename. The alignment files should be named `{base_name}.xf`,
+    `{base_name}.tlt`, `{base_name}.xtilt`. `tilt.com` and `newst.com` files in the same directory may also be read.
+
+    Args:
+        base_name: The basename of the alignment files.
+
+    Returns:
+        ImodAlignment: The alignment object.
+    """
     return ImodAlignment.read(base_name=base_name)
 
 
 def read_aretomo3(aln_path: PATH_TYPE) -> AreTomo3ALN:
+    """Read an AreTomo3 alignment from the specified file.
+
+    Args:
+        aln_path: The path to the .aln file.
+
+    Returns:
+        AreTomo3ALN: The alignment object.
+    """
     return AreTomo3ALN.from_file(aln_path)
 
 
 def read_cdp(cdp_path: PATH_TYPE) -> Alignment:
+    """Read a CryoET Data Portal alignment from the specified file.
+
+    Args:
+        cdp_path: The path to the .json file.
+
+    Returns:
+        Alignment: The alignment object.
+    """
     return Alignment.from_cdp(cdp_path)
 
 
@@ -51,6 +88,16 @@ INFER_READER = {
 
 
 def read(path: PATH_TYPE, reader: str = None) -> Union[AreTomo3ALN, Alignment, ImodAlignment]:
+    """Read alignment files in IMOD, AreTomo3, or CryoET Data Portal format.
+
+    Args:
+        path: The path to the alignment file (or basename for IMOD).
+        reader: The reader to use for the alignment file (one of "imod", "aretomo3" or "cdp"). If None, the reader will
+        be inferred from the file extension.
+
+    Returns:
+        Union[AreTomo3ALN, Alignment, ImodAlignment]: The alignment object.
+    """
     if reader is None:
         _, ext = os.path.splitext(path)
         reader = INFER_READER.get(ext, "imod")

--- a/src/cryoet_alignment/api/write.py
+++ b/src/cryoet_alignment/api/write.py
@@ -16,6 +16,17 @@ def write_imod(
     tiltcom_path: PATH_TYPE = None,
     newstcom_path: PATH_TYPE = None,
 ) -> None:
+    """Write an IMOD alignment to the specified files.
+
+    Args:
+        alignment: The alignment object to write.
+        xf_path: The path to the .xf file.
+        tlt_path: The path to the .tlt file.
+        xtilt_path: The path to the .xtilt file.
+        tiltcom_path: The path to the .tiltcom file.
+        newstcom_path: The path to the .newstcom file.
+    """
+
     alignment.write(
         xf_path=xf_path,
         tlt_path=tlt_path,
@@ -29,15 +40,34 @@ def write_imod_basename(
     alignment: ImodAlignment,
     base_name: str,
 ) -> None:
+    """Write an IMOD alignment to the specified basename. The alignment files will be written as `{base_name}.xf`,
+    `{base_name}.tlt`, `{base_name}.xtilt`, `tilt.com` and `newst.com`.
+
+    Args:
+        alignment: The alignment object to write.
+        base_name: The basename of the alignment files
+    """
     alignment.write(base_name=base_name)
 
 
 def write_aretomo3(aln: AreTomo3ALN, aln_path: PATH_TYPE) -> None:
+    """Write an alignment in AreTomo3 format.
+
+    Args:
+        aln: The alignment object to write.
+        aln_path: The path to write the alignment file to.
+    """
     with open(aln_path, "w") as f:
         f.write(str(aln))
 
 
 def write_cdp(ali: Alignment, cdp_path: PATH_TYPE) -> None:
+    """Write an alignment in CryoET Data Portal format.
+
+    Args:
+        ali: The alignment object to write.
+        cdp_path: The path to write the alignment file to.
+    """
     with open(cdp_path, "w") as f:
         f.write(str(ali))
 
@@ -56,6 +86,14 @@ INFER_WRITER = {
 
 
 def write(alignment: Union[Alignment, AreTomo3ALN, ImodAlignment], path: PATH_TYPE, writer: str = None) -> None:
+    """Write alignment files in IMOD, AreTomo3, or CryoET Data Portal format.
+
+    Args:
+        alignment: The alignment object to write.
+        path: The path to write the alignment file to.
+        writer: The writer to use for the alignment file (one of "imod", "aretomo3" or "cdp"). If None, the writer will
+        be inferred from the alignment object type.
+    """
     if writer is None:
         writer = INFER_WRITER[type(alignment)]
 


### PR DESCRIPTION
Adds examples of usage to the readme, including installation. 

Rename `is_canonical` to `is_portal_standard` to reflect the portal's schema.