### PR TITLE
chore(ci): fix pre-commit job — asdf@v4 and actually run action-validator

### DIFF
--- a/.github/workflows/py-formatting.yml
+++ b/.github/workflows/py-formatting.yml
@@ -10,14 +10,16 @@ jobs:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12.5"
       - name: Install action-validator with asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/install@v4
         with:
           tool_versions: |
             action-validator 0.6.0
+      - name: Validate workflows
+        run: action-validator .github/workflows/*.yml
       - name: check linting
         uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
The pre-commit CI job fails on every PR: `asdf-vm/actions/install@v3` broke with asdf's Go rewrite (`Unable to locate executable file: asdf`).

Fix, matching what is already proven green on copick's `main`:
- Bump `asdf-vm/actions/install` v3 → **v4** (with `checkout@v7` / `setup-python@v7`), keeping the `action-validator 0.6.0` pin.
- Additionally, actually **run** the validator: `action-validator .github/workflows/*.yml`. Previously the tool was installed but never invoked — no pre-commit hook references it — so workflow files were never validated even when the install worked.

Verified locally: all four workflow files (including the edited one) pass action-validator 0.6.0, and `pre-commit run --all-files` is clean.
